### PR TITLE
Develop -> Master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.harvard.eecs</groupId>
     <artifactId>jopt</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Java Optimization</name>
@@ -110,7 +110,7 @@
         <connection>scm:git:git://github.com/blubin/JOpt.git</connection>
         <developerConnection>scm:git:git@github.com/blubin/JOpt.git</developerConnection>
         <url>https://github.com/blubin/JOpt.git/tree/master/</url>
-        <tag>v1.3.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>cplex</groupId>
             <artifactId>cplex</artifactId>
-            <version>12.9</version>
+            <version>12.10</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.harvard.eecs</groupId>
     <artifactId>jopt</artifactId>
-    <version>1.3.5-SNAPSHOT</version>
+    <version>1.3.5</version>
     <packaging>jar</packaging>
 
     <name>Java Optimization</name>
@@ -110,7 +110,7 @@
         <connection>scm:git:git://github.com/blubin/JOpt.git</connection>
         <developerConnection>scm:git:git@github.com/blubin/JOpt.git</developerConnection>
         <url>https://github.com/blubin/JOpt.git/tree/master/</url>
-        <tag>HEAD</tag>
+        <tag>v1.3.5</tag>
     </scm>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.0.0-M1</version>
+                        <configuration>
+                            <source>1.8</source>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
@blubin ,
This is a very small PR to release v1.3.5 of JOpt that declares the CPLEX dependency 12.10. It is mainly to prevent depending projects to have potentially conflicting dependencies if they're using CPLEX 12.10.
I ran the tests to verify that nothing changed in terms of interfaces, as it shouldn't anyway for a non-major version bump.