### PR TITLE
chore(deps): log4j update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ hs_err_pid*
 
 .idea/
 jopt.iml
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.9.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -138,8 +138,9 @@
             <groupId>cplex</groupId>
             <artifactId>cplex</artifactId>
             <version>12.10</version>
-            <scope>provided</scope>
             <optional>true</optional>
+            <scope>system</scope>
+            <systemPath>${env.CPLEX_STUDIO_DIR201}/cplex/lib/cplex.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.datumbox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.harvard.eecs</groupId>
     <artifactId>jopt</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <packaging>jar</packaging>
 
     <name>Java Optimization</name>
@@ -110,7 +110,7 @@
         <connection>scm:git:git://github.com/blubin/JOpt.git</connection>
         <developerConnection>scm:git:git@github.com/blubin/JOpt.git</developerConnection>
         <url>https://github.com/blubin/JOpt.git/tree/master/</url>
-        <tag>v1.4.2</tag>
+        <tag>v1.4.3</tag>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
@blubin I completed the update to the newest log4j version, which required another small change. Also, I'm releasing this as 1.4.2. You should probably reach out to anyone you know that uses JOpt to update to the newest version (and check their own dependencies - Log4j < 2.15 is seriously vulnerable, as you probably read in the [news].(https://www.mcafee.com/blogs/enterprise/mcafee-enterprise-atr/log4shell-vulnerability-is-the-coal-in-our-stocking-for-2021/)