### PR TITLE
Add support for Lazy Constraint Callback

### DIFF
--- a/src/main/java/edu/harvard/econcs/jopt/solver/ILazyConstraintCallback.java
+++ b/src/main/java/edu/harvard/econcs/jopt/solver/ILazyConstraintCallback.java
@@ -1,0 +1,25 @@
+package edu.harvard.econcs.jopt.solver;
+
+/**
+ * This callback method will be called during the solve process of a MIP when a
+ * new integer feasible solution was found. The callback can be used to validate
+ * this solution and add additional constraint to invalidate the solution with
+ * additional lazy constraint if necessary. This is helpful if an enumeration of
+ * all constraint is not feasible (i.e. for an exponential number of
+ * constraints).
+ * 
+ * The callback can only be used if the problem is a MIP.
+ * 
+ * Note that you may need to add the same lazy constraints again in multiple
+ * callback calls in some cases. The safest way is to always add the necessary
+ * constraints to invalidate the solution.
+ * 
+ * @author Manuel Beyeler
+ */
+public interface ILazyConstraintCallback {
+	/**
+	 * This method will be called when an incumbent solution was found.
+	 * @param context the context
+	 */
+	void callback(ILazyConstraintCallbackContext context);
+}

--- a/src/main/java/edu/harvard/econcs/jopt/solver/ILazyConstraintCallbackContext.java
+++ b/src/main/java/edu/harvard/econcs/jopt/solver/ILazyConstraintCallbackContext.java
@@ -1,0 +1,41 @@
+package edu.harvard.econcs.jopt.solver;
+
+import edu.harvard.econcs.jopt.solver.mip.Constraint;
+import edu.harvard.econcs.jopt.solver.mip.Variable;
+
+/**
+ * The context allows access to the current incument solution during a lazy
+ * constraint callback call. Additional constraints may be added using the
+ * {@link #addLazyConstraint(Constraint)} method.
+ * 
+ * @author Manuel Beyeler
+ * @see ILazyConstraintCallback
+ */
+public interface ILazyConstraintCallbackContext {
+	/**
+	 * @param constraint the lazy constraint to add to the problem
+	 */
+	void addLazyConstraint(Constraint constraint);
+
+	/**
+	 * @param variable 
+	 * @return the value of the given variable for this incumbent solution
+	 */
+	double getValue(Variable variable);
+
+	/**
+	 * @param varName 
+	 * @return the value of the given variable for this incumbent solution
+	 */
+	double getValue(String varName);
+
+	/**
+	 * @return the objective value of this incumbent solution
+	 */
+	double getIncumbentObjectiveValue();
+
+	/**
+	 * @return the current relative mip gap
+	 */
+	double getRelativeGap();
+}

--- a/src/main/java/edu/harvard/econcs/jopt/solver/IMIP.java
+++ b/src/main/java/edu/harvard/econcs/jopt/solver/IMIP.java
@@ -351,5 +351,19 @@ public interface IMIP extends Serializable {
 	/////////////////////
 	
 	IMIP typedClone();
+	
+	// Lazy Constraint Callback:
+	////////////////////////////
+	
+	/**
+	 * @param callback the lazy constraint callback or null to remove the callback from this mip
+	 */
+	void setLazyConstraintCallback(ILazyConstraintCallback callback);
+	
+	
+	/**
+	 * @return the lazy constraint callback or null if no callback was set
+	 */
+	ILazyConstraintCallback getLazyConstraintCallback();
 
 }

--- a/src/main/java/edu/harvard/econcs/jopt/solver/mip/MIP.java
+++ b/src/main/java/edu/harvard/econcs/jopt/solver/mip/MIP.java
@@ -30,6 +30,7 @@
  */
 package edu.harvard.econcs.jopt.solver.mip;
 
+import edu.harvard.econcs.jopt.solver.ILazyConstraintCallback;
 import edu.harvard.econcs.jopt.solver.IMIP;
 import edu.harvard.econcs.jopt.solver.MIPException;
 import edu.harvard.econcs.jopt.solver.SolveParam;
@@ -65,6 +66,7 @@ public class MIP implements IMIP, Serializable, Cloneable {
     private boolean isMax;
     private Map<SolveParam, Object> solveParams = new HashMap<>();
     private Collection<Collection<Variable>> variablesOfInterest = null;
+    private ILazyConstraintCallback lazyConstraintCallback = null;
 
     public MIP() {
         resetDefaultSolveParams();
@@ -650,5 +652,15 @@ public class MIP implements IMIP, Serializable, Cloneable {
     public boolean remove(Constraint constraint) {
         return constraints.remove(constraint);
     }
+
+	@Override
+	public void setLazyConstraintCallback(ILazyConstraintCallback callback) {
+		lazyConstraintCallback = callback;
+	}
+
+	@Override
+	public ILazyConstraintCallback getLazyConstraintCallback() {
+		return lazyConstraintCallback;
+	}
 
 }

--- a/src/main/java/edu/harvard/econcs/jopt/solver/server/cplex/CPLEXLazyConstraintCallbackContext.java
+++ b/src/main/java/edu/harvard/econcs/jopt/solver/server/cplex/CPLEXLazyConstraintCallbackContext.java
@@ -1,0 +1,133 @@
+package edu.harvard.econcs.jopt.solver.server.cplex;
+
+import java.util.Map;
+
+import edu.harvard.econcs.jopt.solver.ILazyConstraintCallbackContext;
+import edu.harvard.econcs.jopt.solver.IMIP;
+import edu.harvard.econcs.jopt.solver.MIPException;
+import edu.harvard.econcs.jopt.solver.SolveParam;
+import edu.harvard.econcs.jopt.solver.mip.CompareType;
+import edu.harvard.econcs.jopt.solver.mip.Constraint;
+import edu.harvard.econcs.jopt.solver.mip.LinearTerm;
+import edu.harvard.econcs.jopt.solver.mip.Variable;
+import ilog.concert.IloException;
+import ilog.concert.IloLinearNumExpr;
+import ilog.concert.IloNumVar;
+import ilog.concert.IloRange;
+import ilog.cplex.IloCplex;
+import ilog.cplex.IloCplex.LazyConstraintCallback;;
+
+public class CPLEXLazyConstraintCallbackContext extends LazyConstraintCallback
+		implements ILazyConstraintCallbackContext {
+
+	private IloCplex cplex;
+	private IMIP mip;
+	private Map<String, IloNumVar> vars;
+
+	public CPLEXLazyConstraintCallbackContext(IloCplex cplex, IMIP mip, Map<String, IloNumVar> vars) {
+		this.cplex = cplex;
+		this.mip = mip;
+		this.vars = vars;
+	}
+
+	@Override
+	public void addLazyConstraint(Constraint constraint) {
+		try {
+			if (constraint.hasQuadraticTerms()) {
+				throw new MIPException("Cplex does not support quadratic terms in lazy constraints");
+			}
+
+			// Add Linear Terms:
+			int linearTermsUsed = 0;
+			IloLinearNumExpr numExpr = cplex.linearNumExpr();
+			for (LinearTerm term : constraint.getLinearTerms()) {
+				Variable var = mip.getVar(term.getVarName());
+				if (var == null) {
+					throw new MIPException("Invalid variable name in term: " + term);
+				}
+				if (var.ignore()) {
+					// System.out.println("Skipping term: " + term);
+					continue;
+				}
+				linearTermsUsed++;
+				numExpr.addTerm(term.getCoefficient(), vars.get(term.getVarName()));
+			}
+
+			if (linearTermsUsed == 0) {
+				// nothing to add
+				return;
+			}
+
+			// Use the name description for the name, if available.
+			String name = constraint.getDescription();
+
+			// Add to the MIP, including the comparison and constant:
+			CompareType type = constraint.getType();
+			IloRange iloRange = null;
+			if (CompareType.EQ.equals(type)) {
+				iloRange = cplex.eq(numExpr, constraint.getConstant(), name);
+			} else if (CompareType.LEQ.equals(type)) {
+				iloRange = cplex.le(numExpr, constraint.getConstant(), name);
+			} else if (CompareType.GEQ.equals(type)) {
+				iloRange = cplex.ge(numExpr, constraint.getConstant(), name);
+			} else {
+				throw new MIPException("Invalid constraint type: " + type);
+			}
+
+			// add the new lazy constraint
+			this.add(iloRange);
+		} catch (IloException e) {
+			if (mip.getBooleanSolveParam(SolveParam.DISPLAY_OUTPUT, true)) {
+				e.printStackTrace();
+			}
+			throw new MIPException("Cplex Exception: " + e.toString());
+		}
+	}
+
+	@Override
+	protected void main() throws IloException {
+		mip.getLazyConstraintCallback().callback(this);
+	}
+
+	@Override
+	public double getValue(Variable variable) {
+		return this.getValue(variable.getName());
+	}
+
+	@Override
+	public double getValue(String varName) {
+		try {
+			return super.getValue(vars.get(varName));
+		} catch (IloException e) {
+			if (mip.getBooleanSolveParam(SolveParam.DISPLAY_OUTPUT, true)) {
+				e.printStackTrace();
+			}
+			throw new MIPException("Cplex Exception: " + e.toString());
+		}
+	}
+
+	@Override
+	public double getIncumbentObjectiveValue() {
+		try {
+			return super.getIncumbentObjValue();
+		} catch (IloException e) {
+			if (mip.getBooleanSolveParam(SolveParam.DISPLAY_OUTPUT, true)) {
+				e.printStackTrace();
+			}
+			throw new MIPException("Cplex Exception: " + e.toString());
+		}
+	}
+
+	@Override
+	public double getRelativeGap() {
+		try {
+			return this.getMIPRelativeGap();
+		} catch (IloException e) {
+			if (mip.getBooleanSolveParam(SolveParam.DISPLAY_OUTPUT, true)) {
+				e.printStackTrace();
+			}
+			throw new MIPException("Cplex Exception: " + e.toString());
+		}
+	}
+
+}

--- a/src/main/java/edu/harvard/econcs/jopt/solver/server/cplex/CPlexMIPSolver.java
+++ b/src/main/java/edu/harvard/econcs/jopt/solver/server/cplex/CPlexMIPSolver.java
@@ -92,6 +92,10 @@ public class CPlexMIPSolver implements IMIPSolver {
             Map<Constraint, IloRange> constraintsToIloConstraints = setupConstraints(mip, cplex, vars);
 
             setUpObjective(mip, cplex, vars);
+            
+            if(mip.getLazyConstraintCallback() != null) {
+            	cplex.use(new CPLEXLazyConstraintCallbackContext(cplex, mip, vars));
+            }
 
             logger.debug("Converting mip done. Took: " + (System.currentTimeMillis() - convertStartTime) + " ms");
 

--- a/src/main/java/edu/harvard/econcs/jopt/solver/server/lpsolve/LPSolveMIPSolver.java
+++ b/src/main/java/edu/harvard/econcs/jopt/solver/server/lpsolve/LPSolveMIPSolver.java
@@ -106,6 +106,11 @@ public class LPSolveMIPSolver implements IMIPSolver {
     private static boolean debug = false;
 
     public IMIPResult solve(IMIP mip) throws MIPException {
+    	
+    	if(mip.getLazyConstraintCallback() != null) {
+    		throw new MIPException("Lazy Constraint callback not supported for this solver");
+    	}
+    	
         isCapped = false;
         try {
             Map<String, LinearTerm> objTerms = getObjTerms(mip);


### PR DESCRIPTION
The Lazy Constraint Callback may be used to generate additional constraints for MIPs during the solve process. The solver will call the callback for each incument solution and the user can validate if this incumbent is indeed a feasible solution or add additional constraints to cut it off. This is helpful in settings where it is impossible to enumerate all constraints such that common constraint generation methods need to be applied.